### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
 language: c
 os: linux
 dist: focal
+arch:
+ - amd64
+ - ppc64le
 
 before_install:
   # travis' postgresql-common is missing apt.postgresql.org.sh (2020-05-21)


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 
